### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/adjacent-recommender.yml
+++ b/.github/workflows/adjacent-recommender.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 5 * * 0'   # Every Sunday at 5am UTC
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   recommend-repos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/notnews/archive_news_cc/security/code-scanning/1](https://github.com/notnews/archive_news_cc/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or the specific job) to enforce least privilege while preserving current behavior.  
Because this workflow commits and pushes `README.md`, it needs `contents: write`. No other scopes are required by the shown steps, so the best minimal fix is to add:

```yaml
permissions:
  contents: write
```

Place this at the workflow root (after `on:` block and before `jobs:`), so it applies clearly to all jobs in this file and documents token requirements. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
